### PR TITLE
Fix: Use PASSWORD_DEFAULT for broader compatibility

### DIFF
--- a/api/cadastrar_usuario.php
+++ b/api/cadastrar_usuario.php
@@ -59,7 +59,7 @@ try {
     }
 
     // 2. Criptografa a senha
-    $senhaHash = password_hash($senha, PASSWORD_ARGON2ID);
+    $senhaHash = password_hash($senha, PASSWORD_DEFAULT);
 
     // 3. Insere o novo usuário no banco de dados
     $sql_insert = "INSERT INTO usuarios (nome, email, senha) VALUES (:nome, :email, :senha)";


### PR DESCRIPTION
Changed the password hashing algorithm in `api/cadastrar_usuario.php` from `PASSWORD_ARGON2ID` to `PASSWORD_DEFAULT`. This ensures the registration functionality works correctly on PHP environments that do not have the libsodium extension enabled, making the application more portable and robust.